### PR TITLE
Initialize basic Python project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+PYTHON=python3.11
+VENV=.venv
+UV=$(VENV)/bin/uv
+PIP=$(VENV)/bin/pip
+
+.PHONY: init install test run clean
+
+init:
+$(PYTHON) -m venv $(VENV)
+$(PIP) install uv
+
+install: init
+$(UV) pip install -e .[dev]
+
+test:
+$(UV) pip install pytest
+$(VENV)/bin/pytest -q
+
+run:
+$(VENV)/bin/envzilla
+
+clean:
+rm -rf $(VENV) dist *.egg-info
+echo "Cleaned build and virtual environment"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,39 @@
 # envzilla
-A Python CLI tool to manage .env files with ease. Organize, update, and switch between different environment configurations effortlessly.
+
+Envzilla es una herramienta de línea de comandos para administrar archivos `.env` de forma sencilla. Permite organizar, actualizar y cambiar entre diferentes configuraciones de entorno.
+
+## Requisitos
+- Python 3.11
+- [uv](https://github.com/astral-sh/uv) para la gestión de paquetes
+
+## Instalación rápida
+
+```bash
+make install
+```
+
+El comando anterior crea un entorno virtual en `.venv`, instala `uv` y todas las dependencias del proyecto en modo editable.
+
+## Uso
+
+Para ejecutar la herramienta desde el entorno virtual:
+
+```bash
+make run
+```
+
+## Ejecutar pruebas
+
+```bash
+make test
+```
+
+## Colaborar
+1. Haz un fork del repositorio y clona tu copia.
+2. Crea una rama para tus cambios.
+3. Ejecuta `make install` para preparar el entorno.
+4. Realiza tus modificaciones y añade pruebas si es necesario.
+5. Asegúrate de que `make test` se ejecuta sin errores.
+6. Envía un pull request con una descripción clara de tus cambios.
+
+Cualquier duda o mejora es bienvenida.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,22 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "envzilla"
+version = "0.1.0"
+description = "A Python CLI tool to manage .env files with ease."
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [
+    { name = "The Burrow Hub", email = "contact@burrowhub.org" }
+]
+dependencies = []
+
+[project.scripts]
+envzilla = "envzilla.cli:main"
+
+[project.optional-dependencies]
+dev = [
+    "pytest",
+]

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,2 @@
+from setuptools import setup
+setup()

--- a/src/envzilla/cli.py
+++ b/src/envzilla/cli.py
@@ -1,0 +1,11 @@
+import argparse
+
+
+def main(argv=None):
+    """Entry point for envzilla CLI."""
+    parser = argparse.ArgumentParser(description="envzilla CLI")
+    parser.parse_args(argv)
+    print("envzilla is ready!")
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,0 +1,6 @@
+from envzilla import cli
+
+def test_main_runs(capsys):
+    cli.main([])
+    captured = capsys.readouterr()
+    assert 'envzilla is ready!' in captured.out


### PR DESCRIPTION
## Summary
- add project packaging via `pyproject.toml`
- add minimal `setup.py`
- create CLI skeleton and tests
- create Makefile with uv-based workflow
- expand README with collaboration notes

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683de309ddfc832091b03c6c42173812