### PR TITLE
Add rich table listing for env files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,19 +6,19 @@ PIP=$(VENV)/bin/pip
 .PHONY: init install test run clean
 
 init:
-$(PYTHON) -m venv $(VENV)
-$(PIP) install uv
+	$(PYTHON) -m venv $(VENV)
+	$(PIP) install uv
 
 install: init
-$(UV) pip install -e .[dev]
+	$(UV) pip install -e .[dev]
 
 test:
-$(UV) pip install pytest
-$(VENV)/bin/pytest -q
+	$(UV) pip install pytest
+	$(VENV)/bin/pytest -q
 
 run:
-$(VENV)/bin/envzilla
+	$(VENV)/bin/envzilla
 
 clean:
-rm -rf $(VENV) dist *.egg-info
-echo "Cleaned build and virtual environment"
+	rm -rf $(VENV) dist *.egg-info
+	echo "Cleaned build and virtual environment"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ Para ejecutar la herramienta desde el entorno virtual:
 make run
 ```
 
+### Comandos disponibles
+
+Por ahora existe el comando `list`, que compara un archivo de plantilla
+(por defecto `.env.dist` o `.env.template`) con el resto de archivos `.env`
+del directorio y muestra una tabla con el estado de cada variable.
+Se puede usar `--only-missing` para mostrar solo las variables que faltan o
+que no tienen valor.
+
 ## Ejecutar pruebas
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,10 @@ requires-python = ">=3.11"
 authors = [
     { name = "The Burrow Hub", email = "contact@burrowhub.org" }
 ]
-dependencies = []
+dependencies = [
+    "click>=8",
+    "rich>=13",
+]
 
 [project.scripts]
 envzilla = "envzilla.cli:main"

--- a/src/envzilla/cli.py
+++ b/src/envzilla/cli.py
@@ -1,11 +1,99 @@
-import argparse
+import os
+from pathlib import Path
+from typing import Dict, List
+
+import click
+from rich.console import Console
+from rich.table import Table
 
 
-def main(argv=None):
-    """Entry point for envzilla CLI."""
-    parser = argparse.ArgumentParser(description="envzilla CLI")
-    parser.parse_args(argv)
-    print("envzilla is ready!")
+EMOJI_CHECK = "✅"
+EMOJI_MISSING = "❌"
+EMOJI_EMPTY = "⚠️"
+
+console = Console()
+
+
+def _parse_env_file(path: Path) -> Dict[str, str]:
+    """Parse a .env style file into a dictionary."""
+    data: Dict[str, str] = {}
+    if not path.exists():
+        return data
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :]
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        data[key.strip()] = value.strip()
+    return data
+
+
+def _find_template(base_dir: Path, template: str | None) -> Path:
+    if template:
+        path = base_dir / template
+        if not path.exists():
+            raise click.ClickException(f"Template file {template} not found")
+        return path
+    for name in (".env.dist", ".env.template"):
+        path = base_dir / name
+        if path.exists():
+            return path
+    raise click.ClickException("Template file not found (.env.dist or .env.template)")
+
+
+def _find_env_files(base_dir: Path, template_path: Path) -> List[Path]:
+    files: List[Path] = []
+    for path in base_dir.glob(".env*"):
+        if path == template_path:
+            continue
+        if path.suffix in {".dist", ".template"}:
+            continue
+        files.append(path)
+    files.sort()
+    return files
+
+
+@click.group()
+def main() -> None:
+    """envzilla CLI."""
+    pass
+
+
+@main.command()
+@click.option("--template", type=click.Path(), help="Template file to read")
+@click.option("--only-missing", is_flag=True, help="Show only missing or empty variables")
+def list(template: str | None, only_missing: bool) -> None:  # noqa: D401
+    """List environment variables across files."""
+    base_dir = Path(os.getcwd())
+    template_path = _find_template(base_dir, template)
+    env_files = _find_env_files(base_dir, template_path)
+
+    template_vars = _parse_env_file(template_path)
+    env_data = {f.name: _parse_env_file(f) for f in env_files}
+
+    table = Table(title="Environment variables")
+    table.add_column("Variable")
+    for f in env_files:
+        table.add_column(f.name)
+
+    for var in sorted(template_vars):
+        statuses = []
+        for f in env_files:
+            values = env_data[f.name]
+            if var not in values:
+                statuses.append(EMOJI_MISSING)
+            else:
+                statuses.append(EMOJI_CHECK if values[var] else EMOJI_EMPTY)
+        if only_missing and all(s == EMOJI_CHECK for s in statuses):
+            continue
+        table.add_row(var, *statuses)
+
+    console.print(table)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,25 @@
+from pathlib import Path
+
+from click.testing import CliRunner
+
 from envzilla import cli
 
-def test_main_runs(capsys):
-    cli.main([])
-    captured = capsys.readouterr()
-    assert 'envzilla is ready!' in captured.out
+
+def test_main_runs():
+    runner = CliRunner()
+    result = runner.invoke(cli.main, ["--help"])
+    assert result.exit_code == 0
+    assert "Commands:" in result.output
+
+
+def test_list_command():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(".env.dist").write_text("VAR1=\nVAR2=1\n")
+        Path(".env").write_text("VAR2=foo\n")
+        result = runner.invoke(cli.main, ["list"])
+        assert result.exit_code == 0
+        assert "VAR1" in result.output
+        assert "VAR2" in result.output
+        assert cli.EMOJI_EMPTY in result.output
+        assert cli.EMOJI_CHECK in result.output


### PR DESCRIPTION
## Summary
- replace argparse CLI with click and rich
- implement new `list` command to show env var coverage
- document `list` command in README
- add click & rich deps
- update basic tests

## Testing
- `pip install rich` *(fails: Could not find a version that satisfies the requirement rich)*
- `PYTHONPATH=src pytest -q` *(fails: ModuleNotFoundError: No module named 'rich')*

------
https://chatgpt.com/codex/tasks/task_b_683de736c9088320a145dc0ff82bb69c