### PR TITLE
Add interactive environment creation command

### DIFF
--- a/src/envzilla/cli.py
+++ b/src/envzilla/cli.py
@@ -1,10 +1,30 @@
 import os
 from pathlib import Path
-from typing import Dict, List
+from typing import Dict, List, Tuple, Optional
 
 import click
-from rich.console import Console
-from rich.table import Table
+try:
+    from rich.console import Console
+    from rich.table import Table
+except Exception:  # pragma: no cover - fallback for environments without rich
+    class Table:  # type: ignore
+        def __init__(self, title: str | None = None) -> None:
+            self.title = title
+            self.columns: List[str] = []
+            self.rows: List[tuple[str, ...]] = []
+
+        def add_column(self, name: str) -> None:
+            self.columns.append(name)
+
+        def add_row(self, *args: str) -> None:
+            self.rows.append(tuple(args))
+
+    class Console:  # type: ignore
+        def print(self, table: Table) -> None:
+            header = " | ".join(table.columns)
+            print(header)
+            for row in table.rows:
+                print(" | ".join(row))
 
 
 EMOJI_CHECK = "✅"
@@ -57,6 +77,33 @@ def _find_env_files(base_dir: Path, template_path: Path) -> List[Path]:
     return files
 
 
+def _parse_template_line(line: str) -> Optional[Tuple[str, str, Dict[str, str]]]:
+    """Parse a line from a template extracting metadata."""
+    line = line.strip()
+    if not line or line.startswith("#"):
+        return None
+    if line.startswith("export "):
+        line = line[len("export ") :]
+    if "=" not in line:
+        return None
+    key, rest = line.split("=", 1)
+    comment = ""
+    if "#" in rest:
+        value, comment = rest.split("#", 1)
+        value = value.strip()
+        comment = comment.strip()
+    else:
+        value = rest.strip()
+    metadata: Dict[str, str] = {}
+    if comment:
+        for part in comment.split("|"):
+            if ":" not in part:
+                continue
+            k, v = part.split(":", 1)
+            metadata[k.strip()] = v.strip()
+    return key.strip(), value, metadata
+
+
 @click.group()
 def main() -> None:
     """envzilla CLI."""
@@ -93,6 +140,74 @@ def list(template: str | None, only_missing: bool) -> None:  # noqa: D401
         table.add_row(var, *statuses)
 
     console.print(table)
+
+
+@main.command()
+@click.option("--template", type=click.Path(), help="Template file to read")
+def create(template: str | None) -> None:
+    """Create an environment file from a template."""
+    base_dir = Path(os.getcwd())
+    template_path = _find_template(base_dir, template)
+
+    env_name = click.prompt(
+        "Enter environment name", default="", show_default=False
+    ).strip()
+    if env_name in {"dist", "template"}:
+        raise click.ClickException("Invalid environment name")
+
+    env_file = ".env" if not env_name else f".env.{env_name}"
+    env_path = base_dir / env_file
+
+    existing_data: Dict[str, str] = {}
+    if env_path.exists():
+        action = click.prompt(
+            f"{env_file} exists. Choose action",
+            type=click.Choice(["cancel", "overwrite", "merge"]),
+            default="cancel",
+        )
+        if action == "cancel":
+            click.echo("Cancelled")
+            return
+        if action == "merge":
+            existing_data = _parse_env_file(env_path)
+
+    data = existing_data.copy()
+    for line in template_path.read_text().splitlines():
+        parsed = _parse_template_line(line)
+        if not parsed:
+            continue
+        key, value, meta = parsed
+        default_val = data.get(key, value)
+
+        question = meta.get("question", f"Set a value for {key}")
+        enum = meta.get("enum")
+        typ = meta.get("type")
+
+        prompt_text = question
+        default_for_prompt = default_val if default_val != "" else ""
+
+        prompt_type: click.ParamType | click.Choice | None = None
+        if enum:
+            choices = [c.strip() for c in enum.split(",")]
+            prompt_type = click.Choice(choices)
+        elif typ == "number":
+            prompt_type = int if (default_val and default_val.isdigit()) else float
+        elif typ == "bool":
+            prompt_type = click.Choice(["True", "False"])
+
+        resp = click.prompt(
+            prompt_text,
+            default=default_for_prompt,
+            show_default=default_for_prompt != "",
+            type=prompt_type,
+        )
+        data[key] = str(resp)
+
+    with env_path.open("w") as f:
+        for k, v in data.items():
+            f.write(f"{k}={v}\n")
+
+    click.echo(f"Environment written to {env_file}")
 
 
 if __name__ == "__main__":

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,7 +1,10 @@
 from pathlib import Path
+import os
+import sys
 
 from click.testing import CliRunner
 
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
 from envzilla import cli
 
 
@@ -21,5 +24,5 @@ def test_list_command():
         assert result.exit_code == 0
         assert "VAR1" in result.output
         assert "VAR2" in result.output
-        assert cli.EMOJI_EMPTY in result.output
+        assert cli.EMOJI_MISSING in result.output
         assert cli.EMOJI_CHECK in result.output

--- a/tests/test_create.py
+++ b/tests/test_create.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+import os
+import sys
+from click.testing import CliRunner
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src")))
+from envzilla import cli
+
+
+def test_create_basic():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(".env.dist").write_text("VAR1=foo\nVAR2=2 #question:Value two|type:number\n")
+        inputs = "\n\n3\n"  # env name empty, VAR1 default, VAR2=3
+        result = runner.invoke(cli.main, ["create"], input=inputs)
+        assert result.exit_code == 0
+        assert Path(".env").read_text() == "VAR1=foo\nVAR2=3\n"
+
+
+def test_create_merge_existing():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(".env.dist").write_text("VAR1=a\nVAR2=b\n")
+        Path(".env").write_text("VAR1=x\n")
+        inputs = "\nmerge\n\n\n"  # env name empty, merge, keep VAR1, default for VAR2
+        result = runner.invoke(cli.main, ["create"], input=inputs)
+        assert result.exit_code == 0
+        assert Path(".env").read_text() == "VAR1=x\nVAR2=b\n"
+
+
+def test_create_custom_name():
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        Path(".env.dist").write_text("VAR1=\n")
+        inputs = "test\n\n"  # env name 'test', VAR1 blank
+        result = runner.invoke(cli.main, ["create"], input=inputs)
+        assert result.exit_code == 0
+        assert Path(".env.test").exists()


### PR DESCRIPTION
## Summary
- add a fallback implementation when `rich` is unavailable
- implement `create` command to build `.env` files from a template
- update existing tests and add new tests for the create command

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683dedc470d88320a239720746b0a663