### PR TITLE
Add GitHub Actions for auto versioning and release

### DIFF
--- a/.github/workflows/autoversion.yml
+++ b/.github/workflows/autoversion.yml
@@ -1,0 +1,27 @@
+name: Autoversion
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install Commitizen
+      run: pip install commitizen
+    - name: Bump version
+      run: |
+        git config user.name "GitHub Actions"
+        git config user.email "actions@github.com"
+        cz bump --yes --changelog
+        git push --follow-tags
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,25 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v4
+      with:
+        python-version: '3.11'
+    - name: Install build tools
+      run: |
+        python -m pip install --upgrade pip build
+    - name: Build package
+      run: python -m build
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.PYPI_API_TOKEN }}
+

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Build package
       run: python -m build
     - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@v1
       with:
         password: ${{ secrets.PYPI_API_TOKEN }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,3 +29,4 @@ dev = [
 name = "cz_conventional_commits"
 version = "0.1.0"
 tag_format = "v$version"
+version_files = ["pyproject.toml:version"]


### PR DESCRIPTION
## Summary
- add autoversion workflow running Commitizen on pushes to main
- add workflow to build and publish package to PyPI when a new tag is pushed
- update Commitizen configuration in `pyproject.toml`

## Testing
- `make test` *(fails: .venv/bin/uv not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e104643b88320b746572b527432fb